### PR TITLE
test: refactor tests as prerequisite to split tests into separate files

### DIFF
--- a/projects/solace-message-client/.eslintrc.json
+++ b/projects/solace-message-client/.eslintrc.json
@@ -17,7 +17,8 @@
           {
             "type": "attribute",
             "prefix": [
-              "lib"
+              "lib",
+              "spec"
             ],
             "style": "camelCase"
           }
@@ -27,7 +28,8 @@
           {
             "type": "element",
             "prefix": [
-              "lib"
+              "lib",
+              "spec"
             ],
             "style": "kebab-case"
           }

--- a/projects/solace-message-client/src/lib/testing/message-consumer.fixture.ts
+++ b/projects/solace-message-client/src/lib/testing/message-consumer.fixture.ts
@@ -1,0 +1,74 @@
+import {Message, MessageConsumer, MessageConsumerEvent, MessageConsumerEventName, MessageConsumerProperties, OperationError, Session} from 'solclientjs';
+import {noop} from 'rxjs';
+import {drainMicrotaskQueue} from './testing.utils';
+
+/**
+ * Fixture for a Solace {@link MessageConsumer} to simulate events and messages and to stub functionality.
+ */
+export class MessageConsumerFixture {
+
+  private _callbacks = new Map<MessageConsumerEventName, MessageConsumerEventListener>();
+
+  public messageConsumer: jasmine.SpyObj<Omit<MessageConsumer, 'disposed'> & {disposed: boolean}>;
+  public messageConsumerProperties: MessageConsumerProperties | undefined;
+
+  constructor(session: jasmine.SpyObj<Session>) {
+    this.messageConsumer = jasmine.createSpyObj('messageConsumer', ['on', 'connect', 'disconnect', 'dispose']);
+    this.messageConsumer.disposed = false;
+
+    // Configure session to return the message consumer stub and capture the passed config.
+    session.createMessageConsumer.and.callFake((messageConsumerProperties: MessageConsumerProperties): MessageConsumer => {
+      this.messageConsumerProperties = messageConsumerProperties;
+      return this.messageConsumer;
+    });
+
+    // Capture session callbacks.
+    this.messageConsumer.on.and.callFake((eventName: MessageConsumerEventName, callback: MessageConsumerEventListener): MessageConsumer => {
+      this._callbacks.set(eventName, callback);
+      return this.messageConsumer;
+    });
+
+    // Fire 'DOWN' event when invoking 'disconnect'
+    this.messageConsumer.disconnect.and.callFake(() => this.simulateEvent(MessageConsumerEventName.DOWN));
+
+    // Mark message consumer disposed when calling 'dispose'
+    this.messageConsumer.dispose.and.callFake(() => {
+      this.messageConsumer.disposed = true;
+    });
+  }
+
+  /**
+   * Disables the automatic firing of 'MessageConsumerEventName.DOWN' event when calling 'disconnect'.
+   */
+  public disableFiringDownEventOnDisconnect(): void {
+    this.messageConsumer.disconnect.and.callFake(noop);
+  }
+
+  /**
+   * Simulates the Solace message broker to send given event to the Solace message consumer.
+   */
+  public async simulateEvent(eventName: MessageConsumerEventName, event?: OperationError | MessageConsumerEvent): Promise<void> {
+    await drainMicrotaskQueue();
+
+    const callback = this._callbacks.get(eventName);
+    if (!callback) {
+      throw Error(`[SpecError] No callback registered for event '${eventName}'`);
+    }
+    callback(event as any);
+    await drainMicrotaskQueue();
+  }
+
+  /**
+   * Simulates the Solace message broker to publish a message to the Solace message consumer.
+   */
+  public async simulateMessage(message: Message): Promise<void> {
+    const callback = this._callbacks.get(MessageConsumerEventName.MESSAGE) as (message: Message) => void;
+    if (!callback) {
+      throw Error(`[SpecError] No callback registered for event '${MessageConsumerEventName.MESSAGE}'`);
+    }
+    callback(message);
+    await drainMicrotaskQueue();
+  }
+}
+
+type MessageConsumerEventListener = (() => void) | ((event: MessageConsumerEvent) => void) | ((error: OperationError) => void) | ((message: Message) => void);

--- a/projects/solace-message-client/src/lib/testing/queue-browser.fixture.ts
+++ b/projects/solace-message-client/src/lib/testing/queue-browser.fixture.ts
@@ -1,0 +1,68 @@
+import {Message, OperationError, QueueBrowser, QueueBrowserEventName, QueueBrowserProperties, Session} from 'solclientjs';
+import {drainMicrotaskQueue} from './testing.utils';
+
+/**
+ * Fixture for a Solace {@link QueueBrowser} to simulate events and messages and to stub functionality.
+ */
+export class QueueBrowserFixture {
+
+  private _callbacks = new Map<QueueBrowserEventName, QueueBrowserEventListener>();
+
+  public queueBrowser: jasmine.SpyObj<QueueBrowser>;
+  public queueBrowserProperties: QueueBrowserProperties | undefined;
+
+  constructor(session: jasmine.SpyObj<Session>) {
+    this.queueBrowser = jasmine.createSpyObj('queueBrowser', ['on', 'connect', 'disconnect', 'start', 'stop']);
+
+    // Configure session to return the queue browser stub and capture the passed config.
+    session.createQueueBrowser.and.callFake((queueBrowserProperties: QueueBrowserProperties): QueueBrowser => {
+      this.queueBrowserProperties = queueBrowserProperties;
+      return this.queueBrowser;
+    });
+
+    // Capture session callbacks.
+    this.queueBrowser.on.and.callFake((eventName: QueueBrowserEventName, callback: QueueBrowserEventListener) => {
+      this._callbacks.set(eventName, callback);
+      return this.queueBrowser;
+    });
+
+    // Fire 'DOWN' event when invoking 'disconnect'
+    this.queueBrowser.disconnect.and.callFake(() => {
+      this.simulateEvent(QueueBrowserEventName.DOWN);
+      this.simulateEvent(QueueBrowserEventName.DISPOSED);
+    });
+  }
+
+  /**
+   * Simulates the Solace message broker to send given event to the Solace queue browser.
+   */
+  public async simulateEvent(eventName: QueueBrowserEventName, error?: OperationError): Promise<void> {
+    await drainMicrotaskQueue();
+
+    const callback = this._callbacks.get(eventName);
+    if (!callback) {
+      throw Error(`[SpecError] No callback registered for event '${eventName}'`);
+    }
+    else if (error instanceof OperationError) {
+      ((callback) as (error: OperationError) => void)(error);
+    }
+    else {
+      ((callback) as () => void)();
+    }
+    await drainMicrotaskQueue();
+  }
+
+  /**
+   * Simulates the Solace message broker to publish a message to the Solace queue browser.
+   */
+  public async simulateMessage(message: Message): Promise<void> {
+    const callback = this._callbacks.get(QueueBrowserEventName.MESSAGE) as (message: Message) => void;
+    if (!callback) {
+      throw Error(`[SpecError] No callback registered for event '${QueueBrowserEventName.MESSAGE}'`);
+    }
+    callback(message);
+    await drainMicrotaskQueue();
+  }
+}
+
+type QueueBrowserEventListener = (() => void) | ((error: OperationError) => void) | ((message: Message) => void);

--- a/projects/solace-message-client/src/lib/testing/send-request.fixture.ts
+++ b/projects/solace-message-client/src/lib/testing/send-request.fixture.ts
@@ -1,0 +1,48 @@
+import {Message, RequestError, Session} from 'solclientjs';
+
+/**
+ * Fixture to simulate request-response communication.
+ */
+export class SendRequestFixture {
+
+  private _onResponseCallback?: (session: Session, message: Message, userObject: object) => void;
+  private _onErrorCallback?: (session: Session, error: RequestError, userObject: object) => void;
+
+  public throwErrorOnSend = false;
+  public requestTimeout: number | undefined;
+  public requestMessage: Message | undefined;
+
+  constructor(private _session: jasmine.SpyObj<Session>) {
+    this._session.sendRequest.and.callFake((request, timeout, onResponseCallback, onErrorCallback) => {
+      this._onResponseCallback = onResponseCallback;
+      this._onErrorCallback = onErrorCallback;
+      this.requestMessage = request;
+      this.requestTimeout = timeout;
+      if (this.throwErrorOnSend) {
+        throw Error('Error while sending the request');
+      }
+    });
+  }
+
+  /**
+   * Simulates the Solace message broker to send a response.
+   */
+  public async simulateReply(message: Message): Promise<void> {
+    if (!this._onResponseCallback) {
+      throw Error('[SpecError] No \'replyReceivedCBFunction\' registered');
+    }
+
+    this._onResponseCallback(this._session, message, undefined!);
+  }
+
+  /**
+   * Simulates the Solace message broker to send an error.
+   */
+  public async simulateError(error: RequestError): Promise<void> {
+    if (!this._onErrorCallback) {
+      throw Error('[SpecError] No \'requestFailedCBFunction\' registered');
+    }
+
+    this._onErrorCallback(this._session, error, undefined!);
+  }
+}

--- a/projects/solace-message-client/src/lib/testing/session-provider.ts
+++ b/projects/solace-message-client/src/lib/testing/session-provider.ts
@@ -1,0 +1,19 @@
+import {EnvironmentProviders, makeEnvironmentProviders} from '@angular/core';
+import {SolaceSessionProvider} from '../solace-session-provider';
+import {SessionFixture} from './session.fixture';
+import {SessionProperties} from 'solclientjs';
+
+/**
+ * Creates {@link EnvironmentProviders} with a {@link SolaceSessionProvider} that provides the {@link Session} of the passed {@link SessionFixture}.
+ */
+export function provideSession(sessionFixture: SessionFixture): EnvironmentProviders {
+  const sessionProvider: jasmine.SpyObj<SolaceSessionProvider> = jasmine.createSpyObj('SolaceSessionProvider', ['provide']);
+  sessionProvider.provide.and.callFake((properties: SessionProperties) => {
+    sessionFixture.sessionProvider.provide(properties);
+    return sessionFixture.session;
+  });
+
+  return makeEnvironmentProviders([
+    {provide: SolaceSessionProvider, useValue: sessionProvider},
+  ]);
+}

--- a/projects/solace-message-client/src/lib/testing/session.fixture.ts
+++ b/projects/solace-message-client/src/lib/testing/session.fixture.ts
@@ -1,0 +1,159 @@
+import {Destination, Message, MessageType, Session, SessionEvent, SessionEventCode, SessionProperties} from 'solclientjs';
+import {drainMicrotaskQueue} from './testing.utils';
+import {MessageConsumerFixture} from './message-consumer.fixture';
+import {QueueBrowserFixture} from './queue-browser.fixture';
+import {SendRequestFixture} from './send-request.fixture';
+import {noop} from 'rxjs';
+import {SolaceSessionProvider} from '../solace-session-provider';
+
+/**
+ * Fixture for a Solace {@link Session} to simulate events and messages and to stub functionality.
+ */
+export class SessionFixture {
+
+  private _callbacks = new Map<SessionEventCode, (event: any) => void>();
+
+  public session: jasmine.SpyObj<Session>;
+  public messageConsumerFixture: MessageConsumerFixture;
+  public queueBrowserFixture: QueueBrowserFixture;
+  public sendRequestFixture: SendRequestFixture;
+  /**
+   * Spies for calls to {@link SolaceSessionProvider#provide}.
+   */
+  public sessionProvider: jasmine.SpyObj<SolaceSessionProvider>;
+  /**
+   * Session properties passed to {@link SolaceSessionProvider#provide}.
+   */
+  public sessionProperties: SessionProperties | undefined;
+
+  constructor() {
+    this.session = jasmine.createSpyObj('Session', ['on', 'connect', 'subscribe', 'unsubscribe', 'send', 'dispose', 'disconnect', 'createMessageConsumer', 'createQueueBrowser', 'sendRequest', 'sendReply', 'updateAuthenticationOnReconnect']);
+
+    this.sessionProvider = jasmine.createSpyObj('SolaceSessionProvider', ['provide']);
+    this.sessionProvider.provide.and.callFake((properties: SessionProperties) => {
+      this.sessionProperties = properties;
+      return this.session;
+    });
+
+    this.messageConsumerFixture = new MessageConsumerFixture(this.session);
+    this.queueBrowserFixture = new QueueBrowserFixture(this.session);
+    this.sendRequestFixture = new SendRequestFixture(this.session);
+
+    // Capture session callbacks.
+    this.session.on.and.callFake((eventCode: SessionEventCode, callback: (event: any) => void): Session => {
+      this._callbacks.set(eventCode, callback);
+      return this.session;
+    });
+
+    // Fire 'DISCONNECTED' event when invoking 'disconnect'
+    this.session.disconnect.and.callFake(() => {
+      return this.simulateEvent(SessionEventCode.DISCONNECTED);
+    });
+  }
+
+  /**
+   * Disables the automatic firing of 'SessionEventCode.DISCONNECTED' event when calling 'disconnect'.
+   */
+  public disableFiringDownEventOnDisconnect(): void {
+    this.session.disconnect.and.callFake(noop);
+  }
+
+  /**
+   * Simulates the Solace message broker to send given event to the Solace session.
+   */
+  public async simulateEvent(eventCode: SessionEventCode, correlationKey?: object | string): Promise<void> {
+    await drainMicrotaskQueue();
+    const callback = this._callbacks.get(eventCode);
+    if (!callback) {
+      throw Error(`[SpecError] No callback registered for event '${eventCode}'`);
+    }
+    callback(createSessionEvent(eventCode, correlationKey));
+    await drainMicrotaskQueue();
+  }
+
+  /**
+   * Simulates the Solace message broker to publish a message to the Solace session.
+   */
+  public async simulateMessage(message: Message): Promise<void> {
+    const callback = this._callbacks.get(SessionEventCode.MESSAGE) as ((message: Message) => void);
+    if (!callback) {
+      throw Error(`[SpecError] No callback registered for event '${SessionEventCode.MESSAGE}'`);
+    }
+    callback(message);
+    await drainMicrotaskQueue();
+  }
+
+  /**
+   * Captures the most recent invocation to {@link Session.subscribe}.
+   */
+  public installSessionSubscribeCaptor(): SessionSubscribeCaptor {
+    const captor = new SessionSubscribeCaptor();
+    this.session.subscribe.and.callFake((topic: Destination, requestConfirmation: boolean, correlationKey: string | object | undefined, _requestTimeout: number) => {
+      captor.topic = topic.getName();
+      captor.correlationKey = correlationKey;
+    });
+    return captor;
+  }
+
+  /**
+   * Captures the most recent invocation to {@link Session.unsubscribe}.
+   */
+  public installSessionUnsubscribeCaptor(): SessionSubscribeCaptor {
+    const captor = new SessionSubscribeCaptor();
+    this.session.unsubscribe.and.callFake((topic: Destination, requestConfirmation: boolean, correlationKey: string | object | undefined, _requestTimeout: number) => {
+      captor.topic = topic.getName();
+      captor.correlationKey = correlationKey;
+    });
+    return captor;
+  }
+
+  /**
+   * Captures the most recent invocation to {@link Session.send}.
+   */
+  public installSessionSendCaptor(): SessionSendCaptor {
+    const captor = new SessionSendCaptor();
+    this.session.send.and.callFake((message: Message) => {
+      captor.message = message;
+      captor.destination = message.getDestination()!;
+      captor.type = message.getType();
+    });
+    return captor;
+  }
+}
+
+function createSessionEvent(sessionEventCode: SessionEventCode, correlationKey?: object | string): SessionEvent {
+  // @ts-expect-error: constructor of {@link SessionEvent} is protected.
+  return new SessionEvent(
+    [] /* superclassArgs */,
+    sessionEventCode,
+    null /* infoStr */,
+    null /* responseCode */,
+    null /* errorSubcode */,
+    correlationKey,
+    null/* reason */,
+  );
+}
+
+export class SessionSubscribeCaptor {
+
+  public topic: string | undefined;
+  public correlationKey: string | object | undefined;
+
+  public reset(): void {
+    this.topic = undefined;
+    this.correlationKey = undefined;
+  }
+}
+
+export class SessionSendCaptor {
+
+  public message: Message | undefined;
+  public destination: Destination | undefined;
+  public type: MessageType | undefined;
+
+  public reset(): void {
+    this.message = undefined;
+    this.destination = undefined;
+    this.type = undefined;
+  }
+}

--- a/projects/solace-message-client/src/lib/testing/testing.utils.ts
+++ b/projects/solace-message-client/src/lib/testing/testing.utils.ts
@@ -1,0 +1,43 @@
+import {asyncScheduler} from 'rxjs';
+import {Message, OperationError, RequestError, SolclientFactory} from 'solclientjs';
+
+/**
+ * Waits until all microtasks (Promise) and elapsed macrotasks (setTimeout) completed.
+ */
+export async function drainMicrotaskQueue(): Promise<void> {
+  await new Promise(resolve => asyncScheduler.schedule(resolve));
+}
+
+/**
+ * Creates a fake topic message.
+ */
+export function createTopicMessage(topic: string): Message {
+  const message = SolclientFactory.createMessage();
+  message.setDestination(SolclientFactory.createTopicDestination(topic));
+  return message;
+}
+
+/**
+ * Creates a fake queue message.
+ */
+export function createQueueMessage(queue: string): Message {
+  const message = SolclientFactory.createMessage();
+  message.setDestination(SolclientFactory.createDurableQueueDestination(queue));
+  return message;
+}
+
+/**
+ * Creates a fake operation error.
+ */
+export function createOperationError(): OperationError {
+  // @ts-expect-error: constructor of {@link OperationError} is protected.
+  return new OperationError();
+}
+
+/**
+ * Creates a fake request error.
+ */
+export function createRequestError(): RequestError {
+  // @ts-expect-error: constructor of {@link RequestError} is protected.
+  return new RequestError();
+}

--- a/projects/solace-message-client/tsconfig.lib.json
+++ b/projects/solace-message-client/tsconfig.lib.json
@@ -11,6 +11,7 @@
     ]
   },
   "exclude": [
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "**/testing/"
   ]
 }

--- a/projects/solace-message-client/tsconfig.spec.json
+++ b/projects/solace-message-client/tsconfig.spec.json
@@ -10,6 +10,7 @@
   },
   "include": [
     "**/*.spec.ts",
-    "**/*.d.ts"
+    "**/*.d.ts",
+    "**/testing/"
   ]
 }


### PR DESCRIPTION
The large number of tests in a single file makes it difficult to maintain and add new tests. Initializing the session in 'beforeEach' blocks makes it difficult to get an overview and prevents different setups. As a first step, the fixtures were prepared for reuse and moved to separate files.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/solacecommunity/angular-solace-message-client/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies) 
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
