### PR TITLE
fix(solace-message-client): Don't break complete message parsing if s…

### DIFF
--- a/projects/solace-message-client/src/lib/solace-message-client-consume.spec.ts
+++ b/projects/solace-message-client/src/lib/solace-message-client-consume.spec.ts
@@ -2,7 +2,7 @@ import {MessageEnvelope, SolaceMessageClient} from './solace-message-client';
 import {ObserveCaptor} from '@scion/toolkit/testing';
 import {TestBed} from '@angular/core/testing';
 import {NgZone} from '@angular/core';
-import {MessageConsumerEventName, MessageConsumerProperties, QueueDescriptor, QueueType, SDTFieldType, SDTMapContainer, SessionEventCode, SolclientFactory} from 'solclientjs';
+import {MessageConsumerEventName, MessageConsumerProperties, QueueDescriptor, QueueType, SDTField, SDTFieldType, SDTMapContainer, SDTUnsupportedValueError, SDTValueErrorSubcode, SessionEventCode, SolclientFactory} from 'solclientjs';
 import {SessionFixture} from './testing/session.fixture';
 import {createOperationError, createTopicMessage, drainMicrotaskQueue, initSolclientFactory} from './testing/testing.utils';
 import {provideSession} from './testing/session-provider';
@@ -362,6 +362,49 @@ describe('SolaceMessageClient - Consume', () => {
         .set('key1', 'value')
         .set('key2', true)
         .set('key3', 123),
+    })]);
+  });
+
+  it('not javascript compatible headers should not break consumer', async () => {
+    const sessionFixture = new SessionFixture();
+    const messageConsumerFixture = sessionFixture.messageConsumerFixture;
+    const messageCaptor = new ObserveCaptor<MessageEnvelope>();
+    TestBed.configureTestingModule({
+      providers: [
+        provideSolaceMessageClient({url: 'url', vpnName: 'vpn'}),
+        provideSession(sessionFixture),
+      ],
+    });
+    const solaceMessageClient = TestBed.inject(SolaceMessageClient);
+    await sessionFixture.simulateEvent(SessionEventCode.UP_NOTICE);
+
+    // Subscribe to a topic endpoint
+    solaceMessageClient.consume$('topic').subscribe(messageCaptor);
+
+    // Simulate the message consumer to be connected to the broker
+    await messageConsumerFixture.simulateEvent(MessageConsumerEventName.UP);
+
+    // Simulate to receive a message
+    const message = createTopicMessage('topic');
+    const userPropertyMap = new SDTMapContainer();
+
+    // @ts-expect-error protected class
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const fieldError = new SDTUnsupportedValueError('Value is not supported', SDTValueErrorSubcode.VALUE_OUTSIDE_SUPPORTED_RANGE, '');
+
+    const field = SDTField.create(SDTFieldType.INT64, 1337);
+    (field as any).setError(fieldError);
+
+    userPropertyMap.addField('key1', field);
+    message.setUserPropertyMap(userPropertyMap);
+
+    await messageConsumerFixture.simulateMessage(message);
+
+    // Expect headers to be contained in the envelope
+    expect(messageCaptor.getValues()).toEqual([jasmine.objectContaining<MessageEnvelope>({
+      message: message,
+      headers: new Map()
+        .set('key1', fieldError),
     })]);
   });
 

--- a/projects/solace-message-client/src/lib/ɵsolace-message-client.ts
+++ b/projects/solace-message-client/src/lib/ɵsolace-message-client.ts
@@ -691,7 +691,13 @@ function mapToMessageEnvelope(subscriptionTopic?: string): OperatorFunction<Mess
 function collectHeaders(message: Message): Map<string, unknown> {
   const userPropertyMap = message.getUserPropertyMap();
   return userPropertyMap?.getKeys().reduce((acc, key) => {
-    return acc.set(key, userPropertyMap.getField(key).getValue());
+    const field = userPropertyMap.getField(key);
+    try {
+      return acc.set(key, field.getValue());
+    }
+    catch (e) {
+      return acc.set(key, e);
+    }
   }, new Map<string, unknown>()) ?? new Map<string, unknown>();
 }
 


### PR DESCRIPTION
…ingle header is not JavaScript compatible

JavaScript type number is only precise up to 48bit / 53bit (depends on source of information). If a java long with 64 bit is received, this header field is not parse able in js. Therefore, the solclientjs lib will throw an error.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/solacecommunity/angular-solace-message-client/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added
- [ ] Docs have been added or updated


## PR Type
What kind of change does this PR introduce?

- [x] Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance (changes that improve performance)
- [ ] Test (adding missing tests, refactoring tests; no production code change)
- [ ] Chore (other changes like formatting, updating the license, removal of deprecations, etc)
- [ ] Deps (changes related to updating dependencies) 
- [ ] CI (changes to our CI configuration files and scripts)
- [ ] Revert (revert of a previous commit)
- [ ] Release (publish a new release)
- [ ] Other... Please describe:

## Issue

Issue Number: #

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
